### PR TITLE
Proxy mappings job configuration

### DIFF
--- a/src/proxies.js
+++ b/src/proxies.js
@@ -1,0 +1,8 @@
+'use strict'
+
+module.exports = job => {
+  // Allow custom proxy mappings
+  return job.proxies
+    ? job.proxies
+    : []
+}

--- a/src/reserve.js
+++ b/src/reserve.js
@@ -1,5 +1,6 @@
 const { join } = require('path')
 const cors = require('./cors')
+const proxies = require('./proxies')
 const endpoints = require('./endpoints')
 const { mappings: coverage } = require('./coverage')
 const ui5 = require('./ui5')
@@ -10,6 +11,7 @@ module.exports = job => check({
   port: job.port,
   mappings: [
     cors,
+    ...proxies(job),
     ...endpoints(job),
     ...ui5(job),
     ...coverage(job), {


### PR DESCRIPTION
This PR would allow to add custom mappings to the REserve server.

In the _ui5-test-runner.json_ :

```
{
  ...
  "proxies": [
    {
      "match": "^/otherlib/(.+)",
      "file": "./otherfolder/otherlib/$1"
    }, {
      "match": "^/ui/oDataService/v1/odata/v4/ServiceName/(.+)",
      "url": "http://localhost:18082/odata/v4/ServiceName/$1"
    }
  ]
}
```