### PR TITLE
documentation: using mkdocs

### DIFF
--- a/.github/workflows/pushDocs.yml
+++ b/.github/workflows/pushDocs.yml
@@ -1,0 +1,18 @@
+name: docs
+on:
+  push:
+    branches:
+      - main
+permissions:
+  contents: write
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - run: pip install mkdocs-material
+      - run: pip install mkdocs-minify-plugin
+      - run: mkdocs gh-deploy --force

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -3,15 +3,16 @@
 ## Overview
 
 `ui5-test-runner` can integrate **different browsers** to run the tests. In particular, it is delivered with the following implementations :
+
 * [puppeteer](puppeteer.md) *(chrome)*
 * [playwright](playwright.md)
-  * chromium
-  * firefox
-  * webkit
+    * chromium
+    * firefox
+    * webkit
 * [selenium-webdriver](selenium-webdriver.md)
-  * chrome
-  * firefox
-  * edge
+      * chrome
+      * firefox
+      * edge
 * [jsdom](jsdom.md) *experimental*
 
 The integration consists of a browser instantiation process that is [forked](https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options) from `ui5-test-runner`, allowing the runner to capture the output and to do [in-process communication](https://nodejs.org/api/process.html#processsendmessage-sendhandle-options-callback).
@@ -34,6 +35,7 @@ A JSON file is generated and its **absolute** path is submitted to the command a
 > Probing request JSON file
 
 The probing request file is composed of the following properties :
+
 * `capabilities` : path to a result file the command must generate.
 * `url` : `"about:blank"`
 * `dir` : the working folder allocated for the command.
@@ -58,6 +60,7 @@ When `capabilities` contains a string, the command  **must** generate an answer 
 > Capabilities answer JSON file
 
 The following members are considered :
+
 * `modules` : the list of NPM modules the command depends on, defaulted to `[]`. When modules are specified, the runner is responsible of **finding** the dependencies or **installing** them, when needed.
 * `parallel` : if the command supports parallel execution, defaulted to `true`.
 * `screenshot` : if the command supports screenshot, it contains the extension of the generated files, defaulted to `null` *(screenshots are not supported)*.
@@ -90,6 +93,7 @@ Once the capabilities are known, the command is executed to run the tests. A dif
 > Execution request JSON file
 
 The execution request file is composed of the following properties :
+
 * `capabilities` : the result of the probe operation. It can be used to store information that is available for execution.
 * `modules` : if the probe returned a list of modules, `ui5-test-runner` will ensure to find them either locally or globally. When not found, the runner installs the dependencies globally. Once all the dependencies are resolved, their respective path are given in this object (key is the module name, value is the path).
 * `url` : url of the test page to run.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,75 @@
+site_name: UI5 Test Runner
+site_url: "https://ArnaudBuchholz.github.io/ui5-test-runner/" # required for working 404 page
+repo_name: "ArnaudBuchholz/ui5-test-runner"
+repo_url: "https://github.com/ArnaudBuchholz/ui5-test-runner"
+edit_uri: tree/main/docs/
+docs_dir: "docs" # default
+site_dir: "site" # default
+nav:
+  - Home: README.md
+  - Browser instantiation command: browser.md
+  - Configuration file: configuration.md
+  - Serving and testing the application (a.k.a. legacy mode): legacy.md
+  - Mapping v1 settings to v2: mapping_v1_v2.md
+  - Testing a "remote" application: testing.md
+  - Tips & tricks: tipsNtricks.md
+  - Command line usage: usage.md
+  - ui5-test-runner v2: v2.md
+  - Automation Libraries:
+    - puppeteer: puppeteer.md
+    - jsdom: jsdom.md
+    - playwright: playwright.md
+    - selenium-webdriver: selenium-webdriver.md
+
+theme:
+  name: "material"
+  palette:
+    primary: "blue"
+    accent: "blue"
+  # logo: "images/logo.svg"
+  # favicon: "images/favicon.png"
+  font: false
+  features:
+    - navigation.expand
+    - content.code.copy
+
+# extra_css:
+#   - 'stylesheets/extra.css'
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - codehilite:
+      guess_lang: false
+  - toc:
+      permalink: true
+  # PyMdown Extensions Documentation: https://facelessuser.github.io/pymdown-extensions/extensions/betterem/
+  - pymdownx.betterem:
+      smart_enable: all
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.magiclink
+  - pymdownx.mark
+  - pymdownx.keys
+  - pymdownx.smartsymbols
+  - pymdownx.tabbed
+  - pymdownx.superfences
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+  - pymdownx.caret
+  - pymdownx.snippets
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
+
+dev_addr: "localhost:8000"


### PR DESCRIPTION
## Using Material for Mkdocs to visualize the documentation better:
To view docs locally run from root:
`docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material`. 
open `http://localhost:8000/ui5-test-runner/`

<img width="1342" alt="image" src="https://github.com/ArnaudBuchholz/ui5-test-runner/assets/13335743/1b15cf9b-520a-4229-b988-c01915ab673c">


## Settings --> Pages
<img width="822" alt="image" src="https://github.com/ArnaudBuchholz/ui5-test-runner/assets/13335743/c13b9b54-d4f7-43e8-95ad-e8ccd71e1e36">

## Under Settings --> Actions --> General
<img width="871" alt="image" src="https://github.com/ArnaudBuchholz/ui5-test-runner/assets/13335743/34671e70-35db-44d3-beac-2874485d7604">

## Show in `About` section
I also would suggest showing the URL to the documentation in the about section of the repo like here:
<img width="377" alt="image" src="https://github.com/ArnaudBuchholz/ui5-test-runner/assets/13335743/0a5a2a86-cf75-4520-8dde-540654e8157c">

