### PR TITLE
feat(qunit): improve handling of loose qunit

### DIFF
--- a/src/inject/qunit-hooks.js
+++ b/src/inject/qunit-hooks.js
@@ -24,6 +24,8 @@
   })
 
   QUnit.testStart(function (details) {
+    details.isOpa = isOpa()
+    details.modules = QUnit.config.modules
     return post('QUnit/testStart', details)
   })
 

--- a/src/inject/qunit-hooks.js
+++ b/src/inject/qunit-hooks.js
@@ -18,20 +18,34 @@
     }
   }
 
+  function getModules () {
+    if (QUnit.config && QUnit.config.modules) {
+      return QUnit.config.modules.map(({ name, tests }) => ({
+        name,
+        tests: tests.map(({ name, testId, skip }) => ({ name, testId, skip }))
+      }))
+    }
+    return []
+  }
+
+  function extend (details) {
+    details.isOpa = isOpa()
+    details.modules = getModules()
+    return details
+  }
+
   QUnit.begin(function (details) {
     details.isOpa = isOpa()
     return post('QUnit/begin', details)
   })
 
   QUnit.testStart(function (details) {
-    details.isOpa = isOpa()
-    details.modules = QUnit.config.modules
-    return post('QUnit/testStart', details)
+    return post('QUnit/testStart', extend(details))
   })
 
   QUnit.log(function (log) {
     let ready = false
-    post('QUnit/log', log)
+    post('QUnit/log', extend(log))
       .then(undefined, function () {
         console.error('Failed to POST to QUnit/log (no timestamp)', log)
       })

--- a/src/job.js
+++ b/src/job.js
@@ -107,7 +107,6 @@ function getCommand (cwd) {
     .option('-br, --browser-retry <count>', '[💻🔗🧪] Browser instantiation retries : if the command fails unexpectedly, it is re-executed (0 means no retry)', 1)
 
     // Common to legacy and url
-    .option('-qs, --qunit-strict', '[💻🔗] Strict mode on qunit execution (fails if no modules declared)', boolean, false)
     .option('-pf, --page-filter <regexp>', '[💻🔗] Filter out pages not matching the regexp')
     .option('-pp, --page-params <params>', '[💻🔗] Add parameters to page URL')
     .option('-t, --global-timeout <timeout>', '[💻🔗] Limit the pages execution time, fail the page if it takes longer than the timeout (0 means no timeout)', timeout, 0)

--- a/src/output.js
+++ b/src/output.js
@@ -136,7 +136,7 @@ function output (job, ...args) {
     join(job.reportDir, 'output.txt'),
     args.map(arg => {
       if (typeof arg === 'object') {
-        return JSON.stringify(arg)
+        return JSON.stringify(arg, undefined, 2)
       }
       return arg.toString()
     }).join(' ') + '\n',

--- a/src/qunit-hooks.js
+++ b/src/qunit-hooks.js
@@ -6,7 +6,6 @@ const { UTRError } = require('./error')
 const { getOutput } = require('./output')
 const { basename } = require('path')
 const { filename, stripUrlHash } = require('./tools')
-const $alternateModuleName = Symbol('alternate-module-name')
 
 function error (job, url, details = '') {
   stop(job, url)
@@ -18,11 +17,37 @@ function invalidTestId (job, url, testId) {
   error(job, url, `No QUnit unit test found with id ${testId}`)
 }
 
-function get (job, urlWithHash, testId) {
+function merge (targetModules, modules) {
+  let count = 0;
+  modules.forEach(module => {
+    const { name } = module
+    const targetModule = targetModules.filter(({ name: targetName }) => name === targetName)[0]
+    if (targetModule === undefined) {
+      targetModules.push(module)
+    } else {
+      module.tests.forEach(test => {
+        const targetTest = targetModule.tests.filter(({ testId }) => test.testId === testId)[0]
+        if (!targetTest) {
+          targetModule.tests.push(test)
+        }
+      })
+    }
+    count += module.tests.length
+  })
+  return count
+}
+
+function get (job, urlWithHash, { testId, modules, isOpa } = {}) {
   const url = stripUrlHash(urlWithHash)
   const page = job.qunitPages && job.qunitPages[url]
   if (!page) {
     error(job, url, `No QUnit page found for ${urlWithHash}`)
+  }
+  if (modules && modules.length) {
+    page.count = merge(page.modules, modules)
+  }
+  if (!page.isOpa && isOpa) {
+    page.isOpa = true
   }
   let testModule
   let test
@@ -67,9 +92,10 @@ async function done (job, urlWithHash, report) {
 module.exports = {
   get,
 
-  async begin (job, urlWithHash, { isOpa, totalTests, modules }) {
+  async begin (job, urlWithHash, details) {
+    getOutput(job).debug('qunit', 'begin', urlWithHash, details)
+    const { isOpa, totalTests, modules } = details
     const url = stripUrlHash(urlWithHash)
-    getOutput(job).debug('qunit', 'begin', url, { isOpa, totalTests, modules })
     if (!job.qunitPages) {
       job.qunitPages = {}
     }
@@ -85,27 +111,18 @@ module.exports = {
     job.qunitPages[url] = qunitPage
   },
 
-  async testStart (job, urlWithHash, { module, name, testId, isOpa, modules }) {
-    const url = stripUrlHash(urlWithHash)
-    const page = job.qunitPages && job.qunitPages[url]
-    page.isOpa = !!isOpa
-    if (page.modules.length === 0) {
-      page.modules = modules
-    }
-    const { test } = get(job, urlWithHash, testId)
-    getOutput(job).debug('qunit', 'testStart', url, { module, name, testId })
+  async testStart (job, urlWithHash, details) {
+    getOutput(job).debug('qunit', 'testStart', urlWithHash, details)
+    const { test } = get(job, urlWithHash, details)
     test.start = new Date()
   },
 
-  async log (job, urlWithHash, { module, name, testId, ...log }) {
-    const { url, page, test, testModule } = get(job, urlWithHash, testId)
-    getOutput(job).debug('qunit', 'log', url, { module, name, testId, log })
+  async log (job, urlWithHash, details) {
+    getOutput(job).debug('qunit', 'log', urlWithHash, details)
+    const { url, page, test } = get(job, urlWithHash, details)
+    const { isOpa, modules, module, name, testId, ...log } = details
     if (!test) {
       invalidTestId(job, url, testId)
-    }
-    if (testModule.name !== module) {
-      testModule[$alternateModuleName] = testModule.name
-      testModule.name = module
     }
     if (!test.logs) {
       test.logs = []
@@ -121,10 +138,11 @@ module.exports = {
     }
   },
 
-  async testDone (job, urlWithHash, { name, module, testId, assertions, ...report }) {
+  async testDone (job, urlWithHash, details) {
+    getOutput(job).debug('qunit', 'testDone', urlWithHash, details)
+    const { name, module, testId, assertions, ...report } = details
     const { failed } = report
-    const { url, page, test } = get(job, urlWithHash, testId)
-    getOutput(job).debug('qunit', 'testDone', url, { name, module, testId, assertions, failed })
+    const { url, page, test } = get(job, urlWithHash, { testId })
     if (!test) {
       invalidTestId(job, url, testId)
     }

--- a/src/qunit-hooks.js
+++ b/src/qunit-hooks.js
@@ -18,7 +18,7 @@ function invalidTestId (job, url, testId) {
 }
 
 function merge (targetModules, modules) {
-  let count = 0;
+  let count = 0
   modules.forEach(module => {
     const { name } = module
     const targetModule = targetModules.filter(({ name: targetName }) => name === targetName)[0]

--- a/src/qunit-hooks.spec.js
+++ b/src/qunit-hooks.spec.js
@@ -191,7 +191,7 @@ describe('src/qunit-hooks', () => {
         testId: '1a'
       })
 
-      const { test } = get(job, url, '1a')
+      const { test } = get(job, url, { testId: '1a' })
       expect(test.start).toBeInstanceOf(Date)
     })
   })
@@ -214,7 +214,7 @@ describe('src/qunit-hooks', () => {
         ...getBeginInfo()
       })
       await log(job, url, getLogFor1a())
-      const { test } = get(job, url, '1a')
+      const { test } = get(job, url, { testId: '1a' })
       expect(test.logs).toBeInstanceOf(Array)
       expect(test.logs.length).toStrictEqual(1)
       expect(test.logs[0]).toStrictEqual({
@@ -240,7 +240,7 @@ describe('src/qunit-hooks', () => {
         expected: {},
         runtime: 1506
       })
-      const { test } = get(job, url, '1a')
+      const { test } = get(job, url, { testId: '1a' })
       expect(test.logs.length).toStrictEqual(2)
       expect(test.logs).toStrictEqual([{
         result: true,
@@ -296,7 +296,7 @@ describe('src/qunit-hooks', () => {
       screenshot.mockImplementation(() => '1a-1419.png')
       await log(job, url, getLogFor1a())
       expect(screenshot).toHaveBeenCalledWith(job, url, '1a-1419')
-      const { test } = get(job, url, '1a')
+      const { test } = get(job, url, { testId: '1a' })
       expect(test.logs[0]).toStrictEqual({
         result: true,
         actual: true,
@@ -327,7 +327,7 @@ describe('src/qunit-hooks', () => {
       await log(job, url, getLogFor1a())
       expect(mockGenericError).toHaveBeenCalled()
       expect(job.failed).not.toStrictEqual(true)
-      const { page, test } = get(job, url, '1a')
+      const { page, test } = get(job, url, { testId: '1a' })
       expect(page).toMatchObject({
         isOpa: true,
         failed: 0,
@@ -389,7 +389,7 @@ describe('src/qunit-hooks', () => {
     describe('test success (no screenshot, page.passed += 1)', () => {
       afterEach(() => {
         expect(screenshot).not.toHaveBeenCalled()
-        const { page, test } = get(job, url, '1a')
+        const { page, test } = get(job, url, { testId: '1a' })
         expect(page).toMatchObject({
           isOpa: false,
           failed: 0,
@@ -408,7 +408,7 @@ describe('src/qunit-hooks', () => {
 
       it('store reports', async () => {
         await testDone(job, url, getTestDoneFor1a())
-        const { test } = get(job, url, '1a')
+        const { test } = get(job, url, { testId: '1a' })
         expect(test).toMatchObject({
           report: {
             passed: 1,
@@ -423,7 +423,7 @@ describe('src/qunit-hooks', () => {
           passed: 2,
           total: 2
         })
-        const { test } = get(job, url, '1a')
+        const { test } = get(job, url, { testId: '1a' })
         expect(test).toMatchObject({
           report: {
             passed: 2,
@@ -435,7 +435,7 @@ describe('src/qunit-hooks', () => {
 
     describe('test failure (page.failed += 1)', () => {
       afterEach(() => {
-        const { page, test } = get(job, url, '1a')
+        const { page, test } = get(job, url, { testId: '1a' })
         expect(page).toMatchObject({
           isOpa: false,
           failed: 1,
@@ -461,7 +461,7 @@ describe('src/qunit-hooks', () => {
             total: 1
           })
           expect(screenshot).not.toHaveBeenCalled()
-          const { test } = get(job, url, '1a')
+          const { test } = get(job, url, { testId: '1a' })
           expect(test).toMatchObject({
             report: {
               passed: 0,
@@ -478,7 +478,7 @@ describe('src/qunit-hooks', () => {
             failed: 2,
             total: 2
           })
-          const { test } = get(job, url, '1a')
+          const { test } = get(job, url, { testId: '1a' })
           expect(test).toMatchObject({
             report: {
               passed: 0,
@@ -495,7 +495,7 @@ describe('src/qunit-hooks', () => {
             failed: 1,
             total: 2
           })
-          const { test } = get(job, url, '1a')
+          const { test } = get(job, url, { testId: '1a' })
           expect(test).toMatchObject({
             report: {
               passed: 1,
@@ -530,7 +530,7 @@ describe('src/qunit-hooks', () => {
             total: 1
           })
           expect(screenshot).toHaveBeenCalledWith(job, url, '1a')
-          const { test } = get(job, url, '1a')
+          const { test } = get(job, url, { testId: '1a' })
           expect(test.screenshot).toStrictEqual('1a.png')
         })
 
@@ -606,7 +606,7 @@ describe('src/qunit-hooks', () => {
       })
 
       it('fails the test immediately', () => {
-        const { test } = get(job, url, '1a')
+        const { test } = get(job, url, { testId: '1a' })
         expect(test).toMatchObject({
           report: {
             passed: 0,
@@ -732,26 +732,73 @@ describe('src/qunit-hooks', () => {
       })
     })
 
-    it('accepts new test', async () => {
+    it('accepts new modules', async () => {
       await testStart(jobEarlyStart, url, {
         module: 'test.html?journey=1A',
         name: 'test 1a',
         testId: '1a',
-        modules: getModules()
+        modules: [{
+          name: 'module 1',
+          tests: [{
+            name: 'test 1a',
+            testId: '1a'
+          }]
+        }]
       })
-      const { testModule } = get(jobEarlyStart, url, '1a')
+      const { testModule, page } = get(jobEarlyStart, url, { testId: '1a' })
       expect(testModule.name).toStrictEqual('module 1')
+      expect(page.count).toStrictEqual(1)
     })
 
-    it('appends new tests to existing module', async () => {
+    it('accepts new tests', async () => {
+      await testStart(jobEarlyStart, url, {
+        module: 'test.html?journey=1A',
+        name: 'test 1a',
+        testId: '1a',
+        modules: [{
+          name: 'module 1',
+          tests: [{
+            name: 'test 1a',
+            testId: '1a'
+          }, {
+            name: 'test 1b',
+            testId: '1b'
+          }]
+        }]
+      })
+      const { testModule, page } = get(jobEarlyStart, url, { testId: '1b' })
+      expect(testModule.name).toStrictEqual('module 1')
+      expect(page.count).toStrictEqual(2)
+    })
+
+    it('accepts new modules on top of existing ones', async () => {
       await testStart(jobEarlyStart, url, {
         module: 'test.html?journey=2C',
         name: 'test 2c',
         testId: '2c',
-        modules: getModules()
+        modules: [{
+          name: 'module 1',
+          tests: [{
+            name: 'test 1a',
+            testId: '1a'
+          }, {
+            name: 'test 1b',
+            testId: '1b'
+          }]
+        }, {
+          name: 'module 2',
+          tests: [{
+            name: 'test 2c',
+            testId: '2c'
+          }, {
+            name: 'test 2d',
+            testId: '2d'
+          }]
+        }]
       })
-      const { testModule } = get(jobEarlyStart, url, '2c')
+      const { testModule, page } = get(jobEarlyStart, url, { testId: '2c' })
       expect(testModule.name).toStrictEqual('module 2')
+      expect(page.count).toStrictEqual(4)
     })
   })
 })

--- a/src/simulate.spec.js
+++ b/src/simulate.spec.js
@@ -213,7 +213,7 @@ describe('simulate', () => {
       })
     })
 
-    describe('simple test execution', () => {
+    describe('simple test execution (loose qunit)', () => {
       beforeAll(async () => {
         await setup('simple-early')
         pages = {
@@ -225,7 +225,7 @@ describe('simulate', () => {
           'page1.html': async referer => {
             await post('/_/QUnit/begin', referer, { totalTests: 0, modules: [] })
             await post('/_/QUnit/done', referer, { failed: 0 })
-            await post('/_/QUnit/testStart', referer, { module: 'module', name: 'test', testId: '1' })
+            await post('/_/QUnit/testStart', referer, { module: 'module', name: 'test', testId: '1', modules: [{ name: 'M1', tests: [{ testId: '1' }] }] })
             await post('/_/QUnit/testDone', referer, { testId: '1', failed: 0, passed: 1 })
             await post('/_/QUnit/done', referer, { failed: 0 })
           }

--- a/src/simulate.spec.js
+++ b/src/simulate.spec.js
@@ -213,7 +213,7 @@ describe('simulate', () => {
       })
     })
 
-    describe('simple test execution (--no-qunit-strict)', () => {
+    describe('simple test execution', () => {
       beforeAll(async () => {
         await setup('simple-early')
         pages = {


### PR DESCRIPTION
When QUnit starts automatically *before* the tests are loaded, the runner gets confused. Improved the hooks to be able to catch up on tests that are 'dynamically' declared.