### PR TITLE
feat(puppeteer) : allow to emulate device

### DIFF
--- a/docs/puppeteer.md
+++ b/docs/puppeteer.md
@@ -22,6 +22,8 @@
   -l, --language <lang...>          Language(s) (see rfc5646) (default:
                                     ["en-US"])
   -u, --unsecure                    Disable security features (default: false)
+  --device <name>                   Emulate a device (see puppeteer known
+                                    devices), overrides --viewport-width/height
   --basic-auth-username <username>  Username for basic authentication (default:
                                     "")
   --basic-auth-password <password>  Password for basic authentication (default:
@@ -35,6 +37,8 @@ For instance :
 * `ui5-test-runner --url http://localhost:8080/testsuite.qunit.html -- --unsecure -- --disable-infobars`
 * or *(equivalent)* `ui5-test-runner --url http://localhost:8080/testsuite.qunit.html --browser-args --unsecure --browser-args -- --browser-args --disable-infobars`
 
+
+The `--device` option accepts one of puppeteer's [known device names](https://pptr.dev/api/puppeteer.knowndevices) (e.g. `"iPhone X"`), and emulates its viewport, user agent and touch support. It takes precedence over `--viewport-width`/`--viewport-height`.
 
 ## Implementation notes
 

--- a/src/defaults/puppeteer.js
+++ b/src/defaults/puppeteer.js
@@ -15,6 +15,7 @@ require('./browser')({
       'viewport',
       'language',
       'unsecure',
+      ['--device <name>', 'Emulate a device (see puppeteer known devices), overrides --viewport-width/height', ''],
       ['--basic-auth-username <username>', 'Username for basic authentication', ''],
       ['--basic-auth-password <password>', 'Password for basic authentication', '']
     ]
@@ -78,6 +79,15 @@ require('./browser')({
     console.timeEnd('⏲ launch   ')
 
     page = (await browser.pages())[0]
+
+    if (options.device) {
+      const knownDevices = puppeteer.KnownDevices || {}
+      const device = knownDevices[options.device]
+      if (!device) {
+        throw new Error(`Unknown device "${options.device}", available devices: ${Object.keys(knownDevices).join(', ')}`)
+      }
+      await page.emulate(device)
+    }
 
     if (options.unsecure) {
       await page.setBypassCSP(true)

--- a/test/e2e/PUPPETEER_DEVICE.json
+++ b/test/e2e/PUPPETEER_DEVICE.json
@@ -1,0 +1,9 @@
+{
+  "batchId": "PUPPETEER_DEVICE",
+  "batchLabel": "Puppeteer device emulation",
+  "if": "E2E_IGNORE_BROWSER !== 'true'",
+  "url": ["http://localhost:8080/test/unit/device.qunit.html"],
+  "browser": "$/puppeteer.js",
+  "browserArgs": ["--device", "iPhone X"],
+  "end": "../e2e/check.js --qunit-pages 1"
+}

--- a/test/e2e/PUPPETEER_DEVICE_UNKNOWN.json
+++ b/test/e2e/PUPPETEER_DEVICE_UNKNOWN.json
@@ -1,0 +1,10 @@
+{
+  "batchId": "PUPPETEER_DEVICE_UNKNOWN",
+  "batchLabel": "Puppeteer device emulation with an unknown device name",
+  "if": "E2E_IGNORE_BROWSER !== 'true'",
+  "url": ["http://localhost:8080/test/unit/device.qunit.html"],
+  "browser": "$/puppeteer.js",
+  "browserArgs": ["--device", "no-such-device"],
+  "browserRetry": 0,
+  "end": "../e2e/check.js --failed"
+}

--- a/test/sample.js/webapp/test/unit/device.qunit.html
+++ b/test/sample.js/webapp/test/unit/device.qunit.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Cache-control" content="no-cache, no-store, must-revalidate" />
+		<meta http-equiv="Pragma" content="no-cache" />
+		<meta http-equiv="expires" content="0" />
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<title>Device emulation tests for the UI5 Application: sample.js</title>
+		<script
+			id="sap-ui-bootstrap"
+			src="../../resources/sap-ui-core.js"
+			data-sap-ui-resourceroots='{
+				"unit": "."
+			}'
+			data-sap-ui-async="true"
+			data-sap-ui-oninit="module:unit/device.qunit"
+		></script>
+		<link rel="stylesheet" type="text/css" href="../../resources/sap/ui/thirdparty/qunit-2.css" />
+		<script src="../../resources/sap/ui/thirdparty/qunit-2.js"></script>
+		<script src="../../resources/sap/ui/qunit/qunit-junit.js"></script>
+		<script src="../../resources/sap/ui/qunit/qunit-coverage.js"></script>
+		<script src="../qunit.autostart.js"></script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+		<div id="qunit-fixture"></div>
+	</body>
+</html>

--- a/test/sample.js/webapp/test/unit/device.qunit.js
+++ b/test/sample.js/webapp/test/unit/device.qunit.js
@@ -1,0 +1,21 @@
+/* global QUnit */
+
+// https://api.qunitjs.com/config/autostart/
+QUnit.config.autostart = false
+
+sap.ui.getCore().attachInit(function () {
+  'use strict'
+
+  QUnit.module('Puppeteer device emulation')
+
+  // Expected values match puppeteer's "iPhone X" known device, requested via --device in the batch config
+  QUnit.test('the page is emulated as an iPhone X', function (assert) {
+    assert.ok(/iPhone/.test(navigator.userAgent), `navigator.userAgent reports an iPhone (got: "${navigator.userAgent}")`)
+    assert.strictEqual(window.innerWidth, 375, 'window.innerWidth matches the iPhone X viewport width')
+    assert.ok(navigator.maxTouchPoints > 0, 'touch support is emulated')
+  })
+
+  if (!QUnit.config.started) {
+    QUnit.start()
+  }
+})

--- a/test/sample.js/webapp/test/unit/device.qunit.js
+++ b/test/sample.js/webapp/test/unit/device.qunit.js
@@ -3,19 +3,18 @@
 // https://api.qunitjs.com/config/autostart/
 QUnit.config.autostart = false
 
-sap.ui.getCore().attachInit(function () {
-  'use strict'
 
-  QUnit.module('Puppeteer device emulation')
 
-  // Expected values match puppeteer's "iPhone X" known device, requested via --device in the batch config
-  QUnit.test('the page is emulated as an iPhone X', function (assert) {
-    assert.ok(/iPhone/.test(navigator.userAgent), `navigator.userAgent reports an iPhone (got: "${navigator.userAgent}")`)
-    assert.strictEqual(window.innerWidth, 375, 'window.innerWidth matches the iPhone X viewport width')
-    assert.ok(navigator.maxTouchPoints > 0, 'touch support is emulated')
-  })
+QUnit.module('Puppeteer device emulation')
 
-  if (!QUnit.config.started) {
-    QUnit.start()
-  }
+// Expected values match puppeteer's "iPhone X" known device, requested via --device in the batch config
+QUnit.test('the page is emulated as an iPhone X', function (assert) {
+  assert.ok(/iPhone/.test(navigator.userAgent), `navigator.userAgent reports an iPhone (got: "${navigator.userAgent}")`)
+  assert.strictEqual(window.innerWidth, 375, 'window.innerWidth matches the iPhone X viewport width')
+  assert.ok(navigator.maxTouchPoints > 0, 'touch support is emulated')
 })
+
+if (!QUnit.config.started) {
+  QUnit.start()
+}
+


### PR DESCRIPTION
Hi @ArnaudBuchholz,
I am working on a UI5 App which is intended to be used on mobile only so I thought it would be nice to directly run tests which some emulated device which has touch support so UI5 runs in mobile mode.

Puppeteer supports this so it would be nice if we could add a flag to the test runner to pass through a device. 

I hope it is fine for you, let me know if I can improve something.

I saw you have already switched to version 6 on main but this is not released yet.  So we will need to migrate the code to main as well I guess but only if you agree with the change.

Thx.